### PR TITLE
Add dojo directory to file path

### DIFF
--- a/src/v4/transforms/replace-legacy-core.ts
+++ b/src/v4/transforms/replace-legacy-core.ts
@@ -2,7 +2,7 @@ const dependencies = require('../core/dependencies.json');
 import matchImportsExports from '../matchImportsExports';
 const fs = require('fs-extra');
 const match = /^@dojo\/framework\/(core\/.*)/;
-const excludes = ['core/Destroyable', 'core/Evented', 'core/QueuingEvented', 'core/util'];
+const excludes = ['core/Destroyable', 'core/Evented', 'core/QueuingEvented'];
 
 export = function(file: any, api: any, options: { dry?: boolean }) {
 	let quote: string | undefined;
@@ -17,7 +17,7 @@ export = function(file: any, api: any, options: { dry?: boolean }) {
 				const filesToCopy = [filePath, ...dependencies[filePath]];
 				filesToCopy.forEach((copyPath) => {
 					if (!options.dry) {
-						fs.copySync(`${__dirname}/../${copyPath}`, `${process.cwd()}/src/${copyPath}`);
+						fs.copySync(`${__dirname}/../${copyPath}`, `${process.cwd()}/src/dojo/${copyPath}`);
 					}
 				});
 				if (!quote) {


### PR DESCRIPTION
Core is a common name, so this adds a top level `dojo/` directory.