### PR TITLE
Prevent upgrading non-versioned dependencies

### DIFF
--- a/src/DependencyManager.ts
+++ b/src/DependencyManager.ts
@@ -96,8 +96,12 @@ export class DependencyManager {
 	}
 
 	async updateDependencies(version: string): Promise<void> {
-		const deps = this.getDependencies().filter((dep) => dep.name.includes('@dojo') && !dep.isDevDependency);
-		const devDeps = this.getDependencies().filter((dep) => dep.name.includes('@dojo') && dep.isDevDependency);
+		const deps = this.getDependencies().filter(
+			(dep) => dep.name.includes('@dojo') && !dep.isDevDependency && !!coerce(dep.version)
+		);
+		const devDeps = this.getDependencies().filter(
+			(dep) => dep.name.includes('@dojo') && dep.isDevDependency && !!coerce(dep.version)
+		);
 		await this.install(deps.map(({ name }) => `${name}@${version}`));
 		await this.install(devDeps.map(({ name }) => `${name}@${version}`), true);
 	}

--- a/tests/unit/DependencyManager.ts
+++ b/tests/unit/DependencyManager.ts
@@ -22,6 +22,7 @@ const packageString = `
 	"@dojo/test-extras": "^3.0.0"
   },
   "devDependencies": {
+	"@dojo/cli-upgrade-app": "latest",
 	"@dojo/cli-build-app": "^2.0.0",
 	"some-other-package": "0.0.1"
   }


### PR DESCRIPTION
This PR prevents the upgrade dependencies tool from failing when the version
string is not parseable. It also assumes that the upgrade tool should leave these dependencies alone. Examples of this are:

- "latest"
- "../dojo/cli-upgrade-app/dist/release"