### PR TITLE
Use custom published jscodeshift

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2256,7 +2256,7 @@
         },
         "slice-ansi": {
           "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
         },
@@ -3649,25 +3649,14 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
+        "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
-      },
-      "dependencies": {
-        "combined-stream": {
-          "version": "1.0.6",
-          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        }
       }
     },
     "forwarded": {
@@ -4305,9 +4294,9 @@
       "dev": true
     },
     "get-own-enumerable-property-symbols": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
-      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
+      "integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==",
       "dev": true
     },
     "get-stream": {
@@ -5441,9 +5430,10 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
-    "jscodeshift": {
-      "version": "github:matt-gadd/jscodeshift#ef5a27228c2d39beae494c1de9e17f125b457768",
-      "from": "github:matt-gadd/jscodeshift#ef5a272",
+    "jscodeshift-ts": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/jscodeshift-ts/-/jscodeshift-ts-0.5.1.tgz",
+      "integrity": "sha512-tjVk8L3bH7ZsRQMJTm3qo7wrUl729buMW6PoLxfwWtb/aH1o3YC9SpDD81MKqFRBrGgJ8N7FByh4lVP5od1MkQ==",
       "requires": {
         "babel-plugin-transform-flow-strip-types": "^6.8.0",
         "babel-preset-es2015": "^6.9.0",
@@ -8686,12 +8676,12 @@
       }
     },
     "stringify-object": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
-      "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
       "dev": true,
       "requires": {
-        "get-own-enumerable-property-symbols": "^2.0.1",
+        "get-own-enumerable-property-symbols": "^3.0.0",
         "is-obj": "^1.0.1",
         "is-regexp": "^1.0.0"
       }
@@ -9428,9 +9418,9 @@
       "dev": true
     },
     "widest-line": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
       "dev": true,
       "requires": {
         "string-width": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chalk": "2.4.1",
     "fs-extra": "7.0.0",
     "inquirer": "4.0.2",
-    "jscodeshift": "matt-gadd/jscodeshift#ef5a272",
+    "jscodeshift-ts": "0.5.1",
     "log-symbols": "2.2.0",
     "ora": "3.0.0",
     "semver": "5.5.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import { runTask } from './util';
 import { VersionConfig } from './interfaces';
 import * as logSymbols from 'log-symbols';
 
-const { run: runCodemod } = require('jscodeshift/src/Runner');
+const { run: runCodemod } = require('jscodeshift-ts/src/Runner');
 const glob = require('glob');
 
 export const LATEST_VERSION = 4;

--- a/src/v4/scripts/process-legacy-core.ts
+++ b/src/v4/scripts/process-legacy-core.ts
@@ -1,6 +1,6 @@
 const dependencyTree = require('dependency-tree');
 const glob = require('glob');
-const Runner = require('jscodeshift/src/Runner');
+const Runner = require('jscodeshift-ts/src/Runner');
 const path = require('path');
 const fs = require('fs-extra');
 const { execSync } = require('child_process');

--- a/src/v4/transforms/replace-legacy-core.ts
+++ b/src/v4/transforms/replace-legacy-core.ts
@@ -35,7 +35,7 @@ export = function(file: any, api: any, options: { dry?: boolean }) {
 					}
 				}
 
-				source.value = `${pathToSrc}/${matches[1]}`;
+				source.value = `${pathToSrc}/dojo/${matches[1]}`;
 				return { ...p.node, source: { ...source } };
 			}
 			return p.node;

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -22,10 +22,10 @@ describe('main', () => {
 	beforeEach(() => {
 		sandbox = sinon.sandbox.create();
 		mockModule = new MockModule('../../src/main', require);
-		mockModule.dependencies(['./util', 'jscodeshift/src/Runner', 'inquirer']);
+		mockModule.dependencies(['./util', 'jscodeshift-ts/src/Runner', 'inquirer']);
 		runTaskStub = mockModule.getMock('./util').runTask;
 		codemodStub = mockModule
-			.getMock('jscodeshift/src/Runner')
+			.getMock('jscodeshift-ts/src/Runner')
 			.run.resolves({ error: 0, ok: 0, unchanged: 0, skip: 0 });
 		promptStub = mockModule.getMock('inquirer').prompt;
 		mockDepManager = sinon.createStubInstance(DependencyManager);

--- a/tests/unit/v3/transforms/module-transform-to-framework.ts
+++ b/tests/unit/v3/transforms/module-transform-to-framework.ts
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 
 import * as os from 'os';
 
-let jscodeshift = require('jscodeshift');
+let jscodeshift = require('jscodeshift-ts');
 import moduleTransform = require('../../../../src/v3/transforms/module-transform-to-framework');
 
 jscodeshift = jscodeshift.withParser('typescript');

--- a/tests/unit/v4/scripts/transform-legacy-core.ts
+++ b/tests/unit/v4/scripts/transform-legacy-core.ts
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 
 import * as os from 'os';
 
-let jscodeshift = require('jscodeshift');
+let jscodeshift = require('jscodeshift-ts');
 import moduleTransform from '../../../../src/v4/scripts/transform-legacy-core';
 
 jscodeshift = jscodeshift.withParser('typescript');

--- a/tests/unit/v4/transforms/migration-logging.ts
+++ b/tests/unit/v4/transforms/migration-logging.ts
@@ -6,7 +6,7 @@ import transform, {
 } from '../../../../src/v4/transforms/migration-logging';
 import * as sinon from 'sinon';
 
-const j = require('jscodeshift').withParser('typescript');
+const j = require('jscodeshift-ts').withParser('typescript');
 
 const { describe, it, beforeEach, afterEach } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');

--- a/tests/unit/v4/transforms/replace-legacy-core.ts
+++ b/tests/unit/v4/transforms/replace-legacy-core.ts
@@ -4,7 +4,7 @@ const { assert } = intern.getPlugin('chai');
 import * as rimraf from 'rimraf';
 import * as os from 'os';
 
-let jscodeshift = require('jscodeshift');
+let jscodeshift = require('jscodeshift-ts');
 import moduleTransform = require('../../../../src/v4/transforms/replace-legacy-core');
 
 jscodeshift = jscodeshift.withParser('typescript');

--- a/tests/unit/v4/transforms/replace-legacy-core.ts
+++ b/tests/unit/v4/transforms/replace-legacy-core.ts
@@ -32,13 +32,13 @@ export { Observable } from '@dojo/framework/core/Observable';
 		assert.equal(
 			output,
 			`
-import request from './core/request';
+import request from './dojo/core/request';
 import { EventObject } from '@dojo/framework/core/Evented';
 
 const cjsMod = require('@dojo/framework/core/compare');
 const dynamicImport = import('@dojo/framework/core/DateObject');
 
-export { Observable } from './core/Observable';
+export { Observable } from './dojo/core/Observable';
 `
 				.split(/\r?\n/g)
 				.join(os.EOL)
@@ -59,10 +59,10 @@ export { Observable } from '@dojo/framework/core/Observable';
 		assert.equal(
 			output,
 			`
-import request from '../core/request';
+import request from '../dojo/core/request';
 import { EventObject } from '@dojo/framework/core/Evented';
 
-export { Observable } from '../core/Observable';
+export { Observable } from '../dojo/core/Observable';
 `
 				.split(/\r?\n/g)
 				.join(os.EOL)
@@ -83,10 +83,10 @@ export { Observable } from '@dojo/framework/core/Observable';
 		assert.equal(
 			output,
 			`
-import request from '../../core/request';
+import request from '../../dojo/core/request';
 import { EventObject } from '@dojo/framework/core/Evented';
 
-export { Observable } from '../../core/Observable';
+export { Observable } from '../../dojo/core/Observable';
 `
 				.split(/\r?\n/g)
 				.join(os.EOL)
@@ -107,10 +107,10 @@ export { Observable } from '@dojo/framework/core/Observable';
 		assert.equal(
 			output,
 			`
-import request from '../../src/core/request';
+import request from '../../src/dojo/core/request';
 import { EventObject } from '@dojo/framework/core/Evented';
 
-export { Observable } from '../../src/core/Observable';
+export { Observable } from '../../src/dojo/core/Observable';
 `
 				.split(/\r?\n/g)
 				.join(os.EOL)


### PR DESCRIPTION
Use a published version of the customised jscodeshift version over reference github.

Also fix the import path that core modules are referenced. We updated the legacy modules to be copied into a `dojo` directory but didn't update the import path rewrite.

Resolves #18 
Resolves #19
