### PR TITLE
Only copy files that do not already exist

### DIFF
--- a/src/v4/transforms/migration-logging.ts
+++ b/src/v4/transforms/migration-logging.ts
@@ -54,6 +54,12 @@ export default function(file: any, api: any) {
 		log(`${file.path}: Use of ProjectorMixin is deprecated.`);
 	}
 
+	const hasPath = '@dojo/framework/core/has';
+	// log the path if the location is importing the ProjectorMixin
+	if (!!getImport(j, root, hasPath)) {
+		log(`${file.path}: '${hasPath}' module has been moved to '@dojo/framework/has/preset'`, 'error');
+	}
+
 	// log the path if the loction is importing outlets
 	const outletPath = getImport(j, root, '@dojo/framework/routing/Outlet');
 	if (!!outletPath) {

--- a/src/v4/transforms/migration-logging.ts
+++ b/src/v4/transforms/migration-logging.ts
@@ -55,7 +55,7 @@ export default function(file: any, api: any) {
 	}
 
 	const hasPath = '@dojo/framework/core/has';
-	// log the path if the location is importing the ProjectorMixin
+	// log the path if the location is importing core/has
 	if (!!getImport(j, root, hasPath)) {
 		log(`${file.path}: '${hasPath}' module has been moved to '@dojo/framework/has/preset'`, 'error');
 	}

--- a/src/v4/transforms/replace-legacy-core.ts
+++ b/src/v4/transforms/replace-legacy-core.ts
@@ -2,7 +2,7 @@ const dependencies = require('../core/dependencies.json');
 import matchImportsExports from '../matchImportsExports';
 const fs = require('fs-extra');
 const match = /^@dojo\/framework\/(core\/.*)/;
-const excludes = ['core/Destroyable', 'core/Evented', 'core/QueuingEvented'];
+const excludes = ['core/Destroyable', 'core/Evented', 'core/QueuingEvented', 'core/has'];
 
 export = function(file: any, api: any, options: { dry?: boolean }) {
 	let quote: string | undefined;
@@ -17,7 +17,10 @@ export = function(file: any, api: any, options: { dry?: boolean }) {
 				const filesToCopy = [filePath, ...dependencies[filePath]];
 				filesToCopy.forEach((copyPath) => {
 					if (!options.dry) {
-						fs.copySync(`${__dirname}/../${copyPath}`, `${process.cwd()}/src/dojo/${copyPath}`);
+						const fileExists = fs.pathExistsSync(`${process.cwd()}/src/dojo/${copyPath}`);
+						if (!fileExists) {
+							fs.copySync(`${__dirname}/../${copyPath}`, `${process.cwd()}/src/dojo/${copyPath}`);
+						}
 					}
 				});
 				if (!quote) {

--- a/tests/unit/v4/transforms/migration-logging.ts
+++ b/tests/unit/v4/transforms/migration-logging.ts
@@ -138,6 +138,12 @@ describe('v4/module-logging', () => {
 			assert.isTrue(loggerStub.calledOnce, 'the logger shold have been called');
 		});
 
+		it('should log the file because it is using @dojo/framework/core/has', () => {
+			const source = `import has from '@dojo/framework/core/has';`;
+			transform({ source, path: 'test.ts' }, { jscodeshift: j, stats: () => {} });
+			assert.isTrue(loggerStub.calledOnce, 'the logger shold have been called');
+		});
+
 		it('should log the file because it is using the Outlet', () => {
 			const source = `
 			import Outlet from '@dojo/framework/routing/Outlet';


### PR DESCRIPTION
Updates the transform to only copy files that don't already exist, as the transform delegate off to workers copying working on the same files causes issues with file system.

Also excludes copying the `core/has` modules and reports out that the new location that consumers should update to.