### PR TITLE
Copy `.d.ts` files correctly

### DIFF
--- a/src/v4/transforms/replace-legacy-core.ts
+++ b/src/v4/transforms/replace-legacy-core.ts
@@ -13,8 +13,13 @@ export = function(file: any, api: any, options: { dry?: boolean }) {
 			const { source } = p.node;
 			const matches = match.exec(source.value);
 			if (matches && excludes.indexOf(matches[1]) === -1) {
-				const filePath = `${matches[1]}.ts`;
-				const filesToCopy = [filePath, ...dependencies[filePath]];
+				const moduleImport = matches[1];
+				let filesToCopy: string[] = [];
+				if (dependencies[`${moduleImport}.ts`]) {
+					filesToCopy = [`${moduleImport}.ts`, ...dependencies[`${moduleImport}.ts`]];
+				} else if (dependencies[`${moduleImport}.d.ts`]) {
+					filesToCopy = [`${moduleImport}.d.ts`, ...dependencies[`${moduleImport}.d.ts`]];
+				}
 				filesToCopy.forEach((copyPath) => {
 					if (!options.dry) {
 						const fileExists = fs.pathExistsSync(`${process.cwd()}/src/dojo/${copyPath}`);

--- a/tests/unit/v4/transforms/replace-legacy-core.ts
+++ b/tests/unit/v4/transforms/replace-legacy-core.ts
@@ -45,6 +45,24 @@ export { Observable } from './dojo/core/Observable';
 		);
 	});
 
+	it('should transform legacy package interface imports to local copies', () => {
+		const input = {
+			path: 'src/index.ts',
+			source: `
+import { Response } from '@dojo/framework/core/request/interfaces';
+`
+		};
+		const output = moduleTransform(input, { jscodeshift, stats: () => {} }, { dry: false });
+		assert.equal(
+			output,
+			`
+import { Response } from './dojo/core/request/interfaces';
+`
+				.split(/\r?\n/g)
+				.join(os.EOL)
+		);
+	});
+
 	it('should transform paths relative to src/core', () => {
 		const input = {
 			path: 'src/subdir/index.ts',


### PR DESCRIPTION
**bug**

Currently we are assuming the extension of a module to be `.ts` and this is not correct. A module can also be `.d.ts` so when trying to copy over an interface the transform fails.

Check for `.ts` first, then `.d.ts` in order to return the dependencies.