### PR TITLE
Remove references to Dojo 2/meta from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ npm test
 
 ## Licensing Information
 
-© 2018 [JS Foundation](https://js.foundation/). [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.
+© 2019 [OpenJS Foundation](https://openjsf.org). [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ dojo upgrade
 
 ## Contributing
 
-We appreciate your interest!  Please see the [Dojo 2 Meta Repository](https://github.com/dojo/meta#readme) for the
-Contributing Guidelines.
+We appreciate your interest!  Please see the [Dojo Contributing Guidelines](https://github.com/dojo/framework/blob/master/CONTRIBUTING.md).
 
 Version upgrades are defined in directories starting with "v" and the major version number, (e.g. `v3`). Each version's configuration should be exported as `config` from a `main.ts` file in the directory.
 


### PR DESCRIPTION
Remove "Dojo 2" reference and link to meta repository.