### PR TITLE
V6 updates

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import * as logSymbols from 'log-symbols';
 const { run: runCodemod } = require('jscodeshift-ts/src/Runner');
 const glob = require('glob');
 
-export const LATEST_VERSION = 5;
+export const LATEST_VERSION = 6;
 
 export class UpgradeCommand implements Command {
 	private depManager: DependencyManager;

--- a/src/v6/main.ts
+++ b/src/v6/main.ts
@@ -1,0 +1,12 @@
+import { VersionConfig } from '../interfaces';
+import { resolve } from 'path';
+
+export const config: VersionConfig = {
+	version: 6,
+	transforms: [
+		{
+			name: 'Refactor framework/widget-core to framework/core',
+			path: resolve(__dirname, 'transforms', 'core-refactor.js')
+		}
+	]
+};

--- a/src/v6/transforms/core-refactor.ts
+++ b/src/v6/transforms/core-refactor.ts
@@ -14,14 +14,15 @@ export default function(file: any, api: any) {
 				quote = source.extra.raw.substr(0, 1) === '"' ? 'double' : 'single';
 			}
 
-			if (source.value === '@dojo/framework/widget-core/d') {
-				console.log('P', p);
-				debugger; // tslint:disable-line 
-			} else if (
+			if (
 				source.value === '@dojo/framework/widget-core/d' ||
 				source.value === '@dojo/framework/widget-core/tsx'
 			) {
 				source.value = '@dojo/framework/core/vdom';
+			}
+
+			if (source.value === '@dojo/framework/has/has') {
+				source.value = '@dojo/framework/core/has';
 			}
 
 			source.value = source.value.replace('widget-core', 'core');

--- a/src/v6/transforms/core-refactor.ts
+++ b/src/v6/transforms/core-refactor.ts
@@ -1,0 +1,32 @@
+import { getLineEndings } from '../../util';
+
+export default function(file: any, api: any) {
+	let quote: string | undefined;
+	const j = api.jscodeshift;
+	const lineTerminator = getLineEndings(file.source);
+
+	return j(file.source)
+		.find(j.ImportDeclaration)
+		.replaceWith((p: any) => {
+			const { source } = p.node;
+
+			if (!quote) {
+				quote = source.extra.raw.substr(0, 1) === '"' ? 'double' : 'single';
+			}
+
+			if (source.value === '@dojo/framework/widget-core/d') {
+				console.log('P', p);
+				debugger; // tslint:disable-line 
+			} else if (
+				source.value === '@dojo/framework/widget-core/d' ||
+				source.value === '@dojo/framework/widget-core/tsx'
+			) {
+				source.value = '@dojo/framework/core/vdom';
+			}
+
+			source.value = source.value.replace('widget-core', 'core');
+
+			return { ...p.node, source: { ...source } };
+		})
+		.toSource({ quote: quote || 'single', lineTerminator });
+}

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -6,3 +6,4 @@ import './v4/transforms/replace-legacy-core';
 import './v4/scripts/transform-legacy-core';
 import './v4/transforms/migration-logging';
 import './v5/transforms/consolidate-has';
+import './v6/transforms/core-refactor';

--- a/tests/unit/v6/transforms/core-refactor.ts
+++ b/tests/unit/v6/transforms/core-refactor.ts
@@ -13,6 +13,7 @@ const input = {
 	source: normalizeLineEndings(`
 import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
 import { tsx } from '@dojo/framework/widget-core/tsx';
+import has from '@dojo/framework/has/has';
 `)
 };
 
@@ -24,6 +25,8 @@ describe('refactor-core', () => {
 			normalizeLineEndings(`
 import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { tsx } from '@dojo/framework/core/vdom';
-`));
+import has from '@dojo/framework/core/has';
+`)
+		);
 	});
 });

--- a/tests/unit/v6/transforms/core-refactor.ts
+++ b/tests/unit/v6/transforms/core-refactor.ts
@@ -14,6 +14,7 @@ const input = {
 import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
 import { tsx } from '@dojo/framework/widget-core/tsx';
 import has from '@dojo/framework/has/has';
+import { v, decorate as testDecorate } from '@dojo/framework/widget-core/d';
 `)
 };
 
@@ -26,6 +27,8 @@ describe('refactor-core', () => {
 import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { tsx } from '@dojo/framework/core/vdom';
 import has from '@dojo/framework/core/has';
+import { decorate as testDecorate } from '@dojo/framework/core/util';
+import { v } from '@dojo/framework/core/vdom';
 `)
 		);
 	});

--- a/tests/unit/v6/transforms/core-refactor.ts
+++ b/tests/unit/v6/transforms/core-refactor.ts
@@ -1,0 +1,29 @@
+const { describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import { EOL } from 'os';
+
+const normalizeLineEndings = (str: string) => str.replace(/\r?\n/g, EOL);
+
+let jscodeshift = require('jscodeshift-ts');
+import moduleTransform from '../../../../src/v6/transforms/core-refactor';
+
+jscodeshift = jscodeshift.withParser('typescript');
+
+const input = {
+	source: normalizeLineEndings(`
+import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { tsx } from '@dojo/framework/widget-core/tsx';
+`)
+};
+
+describe('refactor-core', () => {
+	it('transforms widget-core imports to core', () => {
+		const output = moduleTransform(input, { jscodeshift, stats: () => {} });
+		assert.equal(
+			output,
+			normalizeLineEndings(`
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { tsx } from '@dojo/framework/core/vdom';
+`));
+	});
+});


### PR DESCRIPTION
These are basically @nicknisi's changes with a little frosting on them.

- Added conversion from `@dojo/framework/widget-core/d` and `@dojo/framework/widget-core/tsx` to `@dojo/framework/core/vdom`
- Added conversion from `decorate` imports from `@dojo/framework/widget-core/d` to come from `@dojo/framework/core/util`
- Added conversion from `@dojo/framework/has/has` to `@dojo/framework/core/has`

Resolves https://github.com/dojo/cli-upgrade-app/issues/35 and https://github.com/dojo/cli-upgrade-app/issues/34