### PR TITLE
Add i18n formatter => Globalize transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ Sometimes it is useful to build a local package for testing. `@dojo/cli-upgrade-
 
 ## Licensing Information
 
-© 2019 [OpenJS Foundation](https://openjsf.org). [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.
+© 2020 [OpenJS Foundation](https://openjsf.org). [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import * as logSymbols from 'log-symbols';
 const { run: runCodemod } = require('jscodeshift-ts/src/Runner');
 const glob = require('glob');
 
-export const LATEST_VERSION = 6;
+export const LATEST_VERSION = 7;
 
 export class UpgradeCommand implements Command {
 	private depManager: DependencyManager;

--- a/src/v7/main.ts
+++ b/src/v7/main.ts
@@ -1,0 +1,22 @@
+import { resolve } from 'path';
+import { VersionConfig } from '../interfaces';
+
+export const config: VersionConfig = {
+	version: 6,
+	transforms: [
+		{
+			name: 'Replace Dojo i18n formatters with Globalize.js',
+			path: resolve(__dirname, 'transforms', 'use-globalize.js')
+		}
+	],
+
+	dependencies: {
+		add: [],
+		remove: [],
+		updateVersion: '^7.0.0'
+	},
+
+	postTransform() {}
+};
+
+export default config;

--- a/src/v7/transforms/use-globalize.ts
+++ b/src/v7/transforms/use-globalize.ts
@@ -1,0 +1,180 @@
+type JSCodeShift = any;
+type Path = any;
+type Expression = any;
+
+const match = /^@dojo\/framework\/i18n\/(date|number|unit)/;
+
+const methodMap: { [key: string]: { module: string; arity: number; renameTo: string } } = {
+	formatDate: { module: 'date', arity: 3, renameTo: 'formatDate' },
+	formatRelativeTime: { module: 'date', arity: 4, renameTo: 'formatRelativeTime' },
+	getDateFormatter: { module: 'date', arity: 2, renameTo: 'dateFormatter' },
+	getDateParser: { module: 'date', arity: 2, renameTo: 'dateParser' },
+	getRelativeTimeFormatter: { module: 'date', arity: 3, renameTo: 'relativeTimeFormatter' },
+	parseDate: { module: 'date', arity: 3, renameTo: 'parseDate' },
+
+	formatCurrency: { module: 'number', arity: 4, renameTo: 'formatCurrency' },
+	formatNumber: { module: 'number', arity: 3, renameTo: 'formatNumber' },
+	getCurrencyFormatter: { module: 'number', arity: 3, renameTo: 'currencyFormatter' },
+	getNumberFormatter: { module: 'number', arity: 2, renameTo: 'numberFormatter' },
+	getNumberParser: { module: 'number', arity: 2, renameTo: 'numberParser' },
+	getPluralGenerator: { module: 'number', arity: 2, renameTo: 'pluralGenerator' },
+	parseNumber: { module: 'number', arity: 3, renameTo: 'parseNumber' },
+	pluralize: { module: 'number', arity: 3, renameTo: 'plural' },
+
+	formatUnit: { module: 'unit', arity: 4, renameTo: 'formatUnit' },
+	getUnitFormatter: { module: 'unit', arity: 3, renameTo: 'unitFormatter' }
+};
+
+/**
+ * @private
+ * Return an expression that is recast to `Globalize(locale)[method](arg1, arg2, ...argN - 1)`
+ */
+function mapWithLocale(j: JSCodeShift, method: string, args: any[]): Expression {
+	const last = args[args.length - 1];
+	const locale = last.type === 'StringLiteral' ? last : j.logicalExpression('||', last, j.literal(''));
+	return j.callExpression(
+		j.memberExpression(j.callExpression(j.identifier('Globalize'), [locale]), j.identifier(method)),
+		args.slice(0, args.length - 1)
+	);
+}
+
+/**
+ * @private
+ * Return an expression that is recast to `Globalize[method](args)`
+ */
+function mapWithoutLocale(j: JSCodeShift, method: string, args: any[]): Expression {
+	return j.callExpression(j.memberExpression(j.identifier('Globalize'), j.identifier(method)), args);
+}
+
+/**
+ * @private
+ * Return an expression that is recast to either `Globalize(locale)[method](args1, args2, ...argsN - 1)` or
+ * `Globalize[method](args)`, depending on whether it is clear that the final argument is either a locale
+ * string or options object. If the final argument is indeterminate, then nothing is returned.
+ */
+function mapOptionsOrLocale(j: JSCodeShift, method: string, args: any[]): Expression | void {
+	const last = args[args.length - 1];
+	if (last.type === 'StringLiteral' || (last.type === 'Identifier' && last.name === 'locale')) {
+		return j.callExpression(
+			j.memberExpression(j.callExpression(j.identifier('Globalize'), [last]), j.identifier(method)),
+			args.slice(0, args.length - 1)
+		);
+	} else if (last.type !== 'Identifier' || /options/i.test(last.name || '')) {
+		return j.callExpression(j.memberExpression(j.identifier('Globalize'), j.identifier(method)), args);
+	}
+}
+
+/**
+ * @private
+ * A map of maximum formatter arities to functions that return the correct replacement based on the
+ * number of supplied arguments.
+ */
+const mappersByArity: { [key: number]: (j: JSCodeShift, method: string, args: any[]) => Expression | void } = {
+	4: (j: JSCodeShift, method: string, args: any[]) => {
+		switch (args.length) {
+			case 4:
+				return mapWithLocale(j, method, args);
+			case 3:
+				return mapOptionsOrLocale(j, method, args);
+			default:
+				return mapWithoutLocale(j, method, args);
+		}
+	},
+
+	3: (j: JSCodeShift, method: string, args: any[]) => {
+		switch (args.length) {
+			case 3:
+				return mapWithLocale(j, method, args);
+			case 2:
+				return mapOptionsOrLocale(j, method, args);
+			default:
+				return mapWithoutLocale(j, method, args);
+		}
+	},
+
+	2: (j: JSCodeShift, method: string, args: any[]) => {
+		switch (args.length) {
+			case 2:
+				return mapWithLocale(j, method, args);
+			case 1:
+				return mapOptionsOrLocale(j, method, args);
+			default:
+				return mapWithoutLocale(j, method, args);
+		}
+	}
+};
+
+/**
+ * Replace formatters from @dojo/framework/i18n in the provided file with the equivalent Globalize.js methods.
+ * If formatter names are shadowed, or if it is not possible to determine whether a specific argument represents
+ * a locale string or options object, insert a warning comment into the file that is prefixed with
+ * "TODO @dojo/cli-upgrade-app" so that users can easily locate them.
+ */
+export default function(file: any, api: any) {
+	const j = api.jscodeshift;
+	const root = j(file.source);
+
+	const namespaces: { [key: string]: any } = {};
+	const aliases: { [key: string]: string } = {};
+	let matches = new Map();
+
+	root.find(j.ImportDeclaration).replaceWith((path: Path) => {
+		const { source } = path.node;
+		if (match.test(source.value)) {
+			const module = (match.exec(source.value) as string[])[1];
+			matches.set(module, true);
+
+			const [specifier] = path.value.specifiers;
+			if (specifier.type === 'ImportNamespaceSpecifier') {
+				namespaces[specifier.local.name] = module;
+			} else if (specifier.imported) {
+				aliases[specifier.local.name] = specifier.imported.name;
+			}
+
+			if (matches.size > 1) {
+				return;
+			}
+
+			return j.importDeclaration([j.importNamespaceSpecifier(j.identifier('Globalize'))], j.literal('globalize'));
+		}
+		return path.node;
+	});
+
+	root.find(j.CallExpression).replaceWith((path: Path) => {
+		const { arguments: args, callee } = path.value;
+		const ns = callee.object ? callee.object.name : callee.name;
+		let methodName = callee.name || (callee.property && callee.property.name);
+		if (aliases[methodName]) {
+			methodName = aliases[methodName];
+		}
+		if (methodName in methodMap) {
+			const { module: moduleName, arity, renameTo } = methodMap[methodName];
+			if (matches.has(moduleName) && (!callee.object || callee.object.name in namespaces)) {
+				let par = path.parentPath;
+				while (par) {
+					if (par.value.params && par.value.params.some(({ name }: { name: string }) => name === ns)) {
+						path.node.comments = [
+							j.commentLine(` TODO @dojo/cli-upgrade-app: Unmodified: "${ns}" is shadowed.`)
+						];
+						return path.node;
+					}
+					par = par.parentPath;
+				}
+
+				const replacement = mappersByArity[arity](j, renameTo, args);
+				if (!replacement) {
+					path.node.comments = [
+						j.commentLine(
+							' TODO @dojo/cli-upgrade-app: Cannot verify whether the final argument is a locale or options object'
+						)
+					];
+					return path.node;
+				}
+				return replacement;
+			}
+		}
+		return path.node;
+	});
+
+	return root.toSource();
+}

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -7,3 +7,4 @@ import './v4/scripts/transform-legacy-core';
 import './v4/transforms/migration-logging';
 import './v5/transforms/consolidate-has';
 import './v6/transforms/core-refactor';
+import './v7/transforms/use-globalize';

--- a/tests/unit/v7/transforms/use-globalize.ts
+++ b/tests/unit/v7/transforms/use-globalize.ts
@@ -1,0 +1,81 @@
+const { describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+
+import { EOL } from 'os';
+const normalizeLineEndings = (str: string) => str.replace(/\r?\n/g, EOL);
+
+let jscodeshift = require('jscodeshift-ts');
+import moduleTransform from '../../../../src/v7/transforms/use-globalize';
+
+jscodeshift = jscodeshift.withParser('typescript');
+
+const input = {
+	source: normalizeLineEndings(`
+import { formatDate } from '@dojo/framework/i18n/date';
+import { formatCurrency as fc } from '@dojo/framework/i18n/number';
+import * as unit from '@dojo/framework/i18n/unit';
+
+const locale = 'en';
+const options = { datetime: 'full' };
+const unknown = {};
+
+formatDate(new Date());
+formatDate(new Date(), 'en');
+formatDate(new Date(), { datetime: 'full' });
+formatDate(new Date(), options);
+formatDate(new Date(), options, locale);
+formatDate(new Date(), unknown);
+
+function f(formatDate) {
+	formatDate(new Date(), 'en');
+}
+
+unit.formatUnit(12, 'mile-per-hour', { form: 'short' }, 'en');
+unit.getUnitFormatter('mile-per-hour', 'en');
+
+function g(unit) {
+	unit.formatUnit(12, 'mile-per-hour', { form: 'short' }, 'en');
+}
+
+fc(42, 'USD');
+`)
+};
+
+describe('use-globalize', () => {
+	it('replaces formatters from @dojo/framework/i18n with their Globalize counterparts', () => {
+		const output = moduleTransform(input, { jscodeshift, stats: () => {} });
+		assert.equal(
+			output,
+			normalizeLineEndings(`
+import * as Globalize from "globalize";
+
+const locale = 'en';
+const options = { datetime: 'full' };
+const unknown = {};
+
+Globalize.formatDate(new Date());
+Globalize('en').formatDate(new Date());
+Globalize.formatDate(new Date(), { datetime: 'full' });
+Globalize.formatDate(new Date(), options);
+Globalize(locale || "").formatDate(new Date(), options);
+// TODO @dojo/cli-upgrade-app: Cannot verify whether the final argument is a locale or options object
+formatDate(new Date(), unknown);
+
+function f(formatDate) {
+	// TODO @dojo/cli-upgrade-app: Unmodified: "formatDate" is shadowed.
+    formatDate(new Date(), 'en');
+}
+
+Globalize('en').formatUnit(12, 'mile-per-hour', { form: 'short' });
+Globalize('en').unitFormatter('mile-per-hour');
+
+function g(unit) {
+	// TODO @dojo/cli-upgrade-app: Unmodified: "unit" is shadowed.
+    unit.formatUnit(12, 'mile-per-hour', { form: 'short' }, 'en');
+}
+
+Globalize.formatCurrency(42, 'USD');
+`)
+		);
+	});
+});


### PR DESCRIPTION
Replace the date, number, and unit functions provided by `@dojo/framework/i18n` with their Globalize counterparts. If a function call is ambiguous or its name is shadowed, inject a TODO comment warning the developer that they will need to resolve the ambiguity manually.

Also, update the README's copyright year and change "Dojo 2" references to "Dojo".