### PR TITLE
Test harness refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/cli-upgrade-app",
-  "version": "6.0.1-pre",
+  "version": "7.0.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -912,11 +912,12 @@
       }
     },
     "@dojo/cli": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@dojo/cli/-/cli-5.0.0.tgz",
-      "integrity": "sha512-ZMo4or9gLq3uwF+2hAIrSftGod2ZKfiRmM7GA2kcg05VwOwD5sV39cHelMtJdNeKt1OkmYedTXenqXo2neVQvg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@dojo/cli/-/cli-6.0.0.tgz",
+      "integrity": "sha512-wFEfuyH0OeDMJaBQnItzt2vvZLkou6o6ZFV3uG/P8Zxg8a5Ms7rjUv1VcERq3g3GLZGTaQh6oHAheb+lp7VKuw==",
       "dev": true,
       "requires": {
+        "ajv": "6.6.2",
         "chalk": "2.4.1",
         "configstore": "3.1.2",
         "cross-spawn": "5.1.0",
@@ -924,7 +925,7 @@
         "ejs": "2.6.1",
         "fs-extra": "7.0.0",
         "globby": "6.1.0",
-        "inquirer": "4.0.2",
+        "inquirer": "6.2.2",
         "jsonschema": "1.2.4",
         "libnpmsearch": "^2.0.0",
         "pkg-dir": "2.0.0",
@@ -936,6 +937,18 @@
         "yargs": "10.1.2"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.6.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+          "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "ansi-escapes": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
@@ -948,12 +961,6 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "chardet": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-          "dev": true
-        },
         "cli-cursor": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -963,16 +970,11 @@
             "restore-cursor": "^2.0.0"
           }
         },
-        "external-editor": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-          "dev": true,
-          "requires": {
-            "chardet": "^0.4.0",
-            "iconv-lite": "^0.4.17",
-            "tmp": "^0.0.33"
-          }
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
         },
         "figures": {
           "version": "2.0.0",
@@ -993,25 +995,37 @@
           }
         },
         "inquirer": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-4.0.2.tgz",
-          "integrity": "sha512-+f3qDNeZpkhFJ61NBA9jXDrGGhoQuqfEum9A681c9oHoIbGgVqjogKynjB/vNVP+nVu9w3FbFQ35c0ibU0MaIQ==",
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
+          "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
+            "ansi-escapes": "^3.2.0",
+            "chalk": "^2.4.2",
             "cli-cursor": "^2.1.0",
             "cli-width": "^2.0.0",
-            "external-editor": "^2.1.0",
+            "external-editor": "^3.0.3",
             "figures": "^2.0.0",
-            "lodash": "^4.3.0",
+            "lodash": "^4.17.11",
             "mute-stream": "0.0.7",
             "run-async": "^2.2.0",
-            "rx-lite": "^4.0.8",
-            "rx-lite-aggregates": "^4.0.8",
+            "rxjs": "^6.4.0",
             "string-width": "^2.1.0",
-            "strip-ansi": "^4.0.0",
+            "strip-ansi": "^5.0.0",
             "through": "^2.3.6"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            }
           }
         },
         "is-fullwidth-code-point": {
@@ -1102,23 +1116,25 @@
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
           }
         }
       }
     },
     "@dojo/scripts": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@dojo/scripts/-/scripts-3.1.0.tgz",
-      "integrity": "sha512-LRUeGVam7IizhvgcRU6zu4bmBXeFzuKcgeleAUHZP1NPa+DROPdidBWIdVeKL5jVHqCnTfYgAqqorsgkftOj2g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@dojo/scripts/-/scripts-4.0.2.tgz",
+      "integrity": "sha512-qDTpv21pcrL4k2cHCgwVnRrXR+IRqFk/yxJ5uwRo+kC5saEfDz2L8InfuXwTPt4zzvYiEGXQ/X98cFaruh+YiA==",
       "dev": true,
       "requires": {
         "chalk": "~2.4.0",
@@ -1128,7 +1144,7 @@
         "rxjs": "^5.5.6",
         "tslint": "~5.11.0",
         "tslint-language-service": "~0.9.9",
-        "typescript": "~2.6.2",
+        "typescript": "3.4.5",
         "yargs": "~10.1.2"
       },
       "dependencies": {
@@ -1235,9 +1251,9 @@
           }
         },
         "typescript": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-          "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+          "version": "3.4.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+          "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
           "dev": true
         }
       }
@@ -9137,21 +9153,6 @@
         "aproba": "^1.1.1"
       }
     },
-    "rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
-    },
-    "rx-lite-aggregates": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "dev": true,
-      "requires": {
-        "rx-lite": "*"
-      }
-    },
     "rxjs": {
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
@@ -10179,9 +10180,9 @@
       }
     },
     "uglify-js": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
-      "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.1.tgz",
+      "integrity": "sha512-W7KxyzeaQmZvUFbGj4+YFshhVrMBGSg2IbcYAjGWGvx8DHvJMclbTDMpffdxFUGPBHjIytk7KJUR/KUXstUGDw==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "tslib": "1.8.1"
   },
   "devDependencies": {
-    "@dojo/cli": "^5.0.0",
-    "@dojo/scripts": "~3.1.0",
+    "@dojo/cli": "^6.0.0",
+    "@dojo/scripts": "~4.0.2",
     "@types/inquirer": "6.5.0",
     "@types/log-symbols": "2.0.0",
     "@types/mockery": "1.4.29",

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import * as logSymbols from 'log-symbols';
 const { run: runCodemod } = require('jscodeshift/src/Runner');
 const glob = require('glob');
 
-export const LATEST_VERSION = 6;
+export const LATEST_VERSION = 7;
 
 export class UpgradeCommand implements Command {
 	private depManager: DependencyManager;

--- a/src/v7/main.ts
+++ b/src/v7/main.ts
@@ -1,0 +1,18 @@
+import { VersionConfig } from '../interfaces';
+import { resolve } from 'path';
+
+export const config: VersionConfig = {
+	version: 7,
+	transforms: [
+		{
+			name: 'Refactor framework/testing to framework/testing/harness',
+			path: resolve(__dirname, 'transforms', 'new-test-harness.js')
+		}
+	],
+	dependencies: {
+		add: [],
+		remove: [],
+		updateVersion: '^7.0.0'
+	},
+	postTransform() {}
+};

--- a/src/v7/transforms/new-test-harness.ts
+++ b/src/v7/transforms/new-test-harness.ts
@@ -1,0 +1,24 @@
+import { getLineEndings } from '../../util';
+
+export default function(file: any, api: any) {
+	let quote: string | undefined;
+	const j = api.jscodeshift;
+	const lineTerminator = getLineEndings(file.source);
+
+	return j(file.source)
+		.find(j.ImportDeclaration)
+		.replaceWith((p: any) => {
+			const { source } = p.node;
+
+			if (!quote) {
+				quote = source.extra.raw.substr(0, 1) === '"' ? 'double' : 'single';
+			}
+
+			if (source.value && source.value.startsWith('@dojo/framework/testing/')) {
+				source.value = source.value.replace('@dojo/framework/testing/', '@dojo/framework/testing/harness/');
+			}
+
+			return { ...p.node, source: { ...source } };
+		})
+		.toSource({ quote: quote || 'single', lineTerminator });
+}

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -7,3 +7,4 @@ import './v4/scripts/transform-legacy-core';
 import './v4/transforms/migration-logging';
 import './v5/transforms/consolidate-has';
 import './v6/transforms/core-refactor';
+import './v7/transforms/new-test-harness';

--- a/tests/unit/v7/transforms/new-test-harness.ts
+++ b/tests/unit/v7/transforms/new-test-harness.ts
@@ -19,7 +19,7 @@ import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
 };
 
 describe('new-test-harness', () => {
-	it('transforms widget-core imports to core', () => {
+	it('transforms testing imports to testing/harness', () => {
 		const output = moduleTransform(input, { jscodeshift, stats: () => {} });
 		assert.equal(
 			output,

--- a/tests/unit/v7/transforms/new-test-harness.ts
+++ b/tests/unit/v7/transforms/new-test-harness.ts
@@ -1,0 +1,34 @@
+const { describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import { EOL } from 'os';
+
+const normalizeLineEndings = (str: string) => str.replace(/\r?\n/g, EOL);
+
+let jscodeshift = require('jscodeshift');
+import moduleTransform from '../../../../src/v7/transforms/new-test-harness';
+
+jscodeshift = jscodeshift.withParser('ts');
+
+const input = {
+	source: normalizeLineEndings(`
+import { tsx } from '@dojo/framework/core/vdom';
+import harness from '@dojo/framework/testing/harness';
+import { createBreakpointMock } from '@dojo/framework/testing/mocks/middleware/breakpoint';
+import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
+`)
+};
+
+describe('new-test-harness', () => {
+	it('transforms widget-core imports to core', () => {
+		const output = moduleTransform(input, { jscodeshift, stats: () => {} });
+		assert.equal(
+			output,
+			normalizeLineEndings(`
+import { tsx } from '@dojo/framework/core/vdom';
+import harness from '@dojo/framework/testing/harness/harness';
+import { createBreakpointMock } from '@dojo/framework/testing/harness/mocks/middleware/breakpoint';
+import assertionTemplate from '@dojo/framework/testing/harness/assertionTemplate';
+`)
+		);
+	});
+});


### PR DESCRIPTION
Modifies any imports starting with `'@dojo/framework/testing/'` to instead start with `'@dojo/framework/testing/harness'`.

Resolves #51 