### PR TITLE
Outlet to route

### DIFF
--- a/src/v7/main.ts
+++ b/src/v7/main.ts
@@ -7,6 +7,10 @@ export const config: VersionConfig = {
 		{
 			name: 'Refactor framework/testing to framework/testing/harness',
 			path: resolve(__dirname, 'transforms', 'new-test-harness.js')
+		},
+		{
+			name: 'Update Outlet dependencies to Route',
+			path: resolve(__dirname, 'transforms', 'outlet-to-route.js')
 		}
 	],
 	dependencies: {

--- a/src/v7/transforms/outlet-to-route.ts
+++ b/src/v7/transforms/outlet-to-route.ts
@@ -1,0 +1,85 @@
+import { getLineEndings } from '../../util';
+
+export default function(file: any, api: any) {
+	let quote: string | undefined;
+	const j = api.jscodeshift;
+	const lineTerminator = getLineEndings(file.source);
+	let jFile = j(file.source);
+	let importScope: any = null;
+
+	jFile.find(j.ImportDeclaration).forEach((path: any) => {
+		const { source, specifiers } = path.node;
+		if (source.value && source.value === '@dojo/framework/routing/Outlet') {
+			source.value = '@dojo/framework/routing/Route';
+			if (specifiers) {
+				specifiers.forEach((specifier: any) => {
+					if (specifier.type === 'ImportSpecifier') {
+						if (specifier.imported.name === 'Outlet') {
+							specifier.imported.name = 'Route';
+							if (specifier.local.name === 'Outlet') {
+								specifier.local.name = 'Route';
+								importScope = path.scope;
+							}
+						}
+					} else if (specifier.type === 'ImportDefaultSpecifier' && specifier.local.name === 'Outlet') {
+						specifier.local.name = 'Route';
+						importScope = path.scope;
+					}
+				});
+			}
+		}
+
+		if (!quote) {
+			quote = source.extra.raw.substr(0, 1) === '"' ? 'double' : 'single';
+		}
+
+		return { ...path.node, source: { ...source }, specifiers: [...specifiers] };
+	});
+
+	if (importScope) {
+		jFile
+			.find(j.Identifier, { name: 'Outlet' })
+			.filter(function(path: any) {
+				const parent = path.parent.node;
+
+				if (j.MemberExpression.check(parent) && parent.property === path.node && !parent.computed) {
+					// obj.oldName
+					return false;
+				}
+
+				if (j.Property.check(parent) && parent.key === path.node && !parent.computed) {
+					// { oldName: 3 }
+					return false;
+				}
+
+				if (j.MethodDefinition.check(parent) && parent.key === path.node && !parent.computed) {
+					// class A { oldName() {} }
+					return false;
+				}
+
+				if (j.ClassProperty.check(parent) && parent.key === path.node && !parent.computed) {
+					// class A { oldName = 3 }
+					return false;
+				}
+
+				if (j.JSXAttribute.check(parent) && parent.name === path.node && !parent.computed) {
+					// <Foo oldName={oldName} />
+					return false;
+				}
+
+				return true;
+			})
+			.forEach(function(path: any) {
+				let scope = path.scope;
+				while (scope) {
+					if (scope.declares('Outlet') && scope !== importScope) {
+						return;
+					}
+					scope = scope.parent;
+				}
+				path.get('name').replace('Route');
+			});
+	}
+
+	return jFile.toSource({ quote: quote || 'single', lineTerminator });
+}

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -8,3 +8,4 @@ import './v4/transforms/migration-logging';
 import './v5/transforms/consolidate-has';
 import './v6/transforms/core-refactor';
 import './v7/transforms/new-test-harness';
+import './v7/transforms/outlet-to-route';

--- a/tests/unit/v4/scripts/transform-legacy-core.ts
+++ b/tests/unit/v4/scripts/transform-legacy-core.ts
@@ -33,13 +33,13 @@ const request: {
     put(url: string, options?: RequestOptions): UploadObservableTask<Response>;
 
     setDefaultProvider(provider: Provider): void;
-} = <any>function request(url: string, options: RequestOptions = {}): Task<Response> {
+} = function request(url: string, options: RequestOptions = {}): Task<Response> {
     try {
         return providerRegistry.match(url, options)(url, options);
     } catch (error) {
         return Task.reject<Response>(error);
     }
-};
+} as any;
 
 ['DELETE', 'GET', 'HEAD', 'OPTIONS'].forEach((method) => {
     Object.defineProperty(request, method.toLowerCase(), {
@@ -56,7 +56,7 @@ const request: {
         value(url: string, options: RequestOptions = {}): UploadObservableTask<Response> {
             options = Object.create(options);
             options.method = method;
-            return <UploadObservableTask<Response>>request(url, options);
+            return request(url, options) as UploadObservableTask<Response>;
         }
     });
 });
@@ -106,13 +106,13 @@ const request: {
     put(url: string, options?: RequestOptions): UploadObservableTask<Response>;
 
     setDefaultProvider(provider: Provider): void;
-} = <any>function request(url: string, options: RequestOptions = {}): Task<Response> {
+} = function request(url: string, options: RequestOptions = {}): Task<Response> {
     try {
         return providerRegistry.match(url, options)(url, options);
     } catch (error) {
         return Task.reject<Response>(error);
     }
-};
+} as any;
 
 ['DELETE', 'GET', 'HEAD', 'OPTIONS'].forEach((method) => {
     Object.defineProperty(request, method.toLowerCase(), {
@@ -129,7 +129,7 @@ const request: {
         value(url: string, options: RequestOptions = {}): UploadObservableTask<Response> {
             options = Object.create(options);
             options.method = method;
-            return <UploadObservableTask<Response>>request(url, options);
+            return request(url, options) as UploadObservableTask<Response>;
         }
     });
 });

--- a/tests/unit/v7/transforms/outlet-to-route.ts
+++ b/tests/unit/v7/transforms/outlet-to-route.ts
@@ -1,0 +1,186 @@
+const { describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import { EOL } from 'os';
+
+const normalizeLineEndings = (str: string) => str.replace(/\r?\n/g, EOL);
+
+let jscodeshift = require('jscodeshift');
+import moduleTransform from '../../../../src/v7/transforms/outlet-to-route';
+
+jscodeshift = jscodeshift.withParser('tsx');
+
+const changeDefaultImportInput = {
+	source: normalizeLineEndings(`
+import { tsx, w } from '@dojo/framework/core/vdom';
+import Outlet from '@dojo/framework/routing/Outlet';
+const Foo: any = {};
+function foo() {
+    return <Outlet/>;
+}
+function bar() {
+    return w(Outlet);
+}
+function baz() {
+    return w(Foo);
+}
+`)
+};
+
+const changeImportInput = {
+	source: normalizeLineEndings(`
+import { tsx, w } from '@dojo/framework/core/vdom';
+import { Outlet } from '@dojo/framework/routing/Outlet';
+function foo() {
+    return <Outlet/>;
+}
+function bar() {
+    return w(Outlet);
+}
+if (true) {
+    const Outlet = 'A Bad Idea';
+    console.log(Outlet);
+}
+`)
+};
+
+const changeImportInputNewScope = {
+	source: normalizeLineEndings(`
+import { tsx, w } from '@dojo/framework/core/vdom';
+import { Outlet } from '@dojo/framework/routing/Outlet';
+function foo() {
+    return <Outlet/>;
+}
+function bar() {
+    return w(Outlet);
+}
+(() => {
+    const Outlet = 'A Bad Idea';
+    console.log(Outlet);
+})();
+`)
+};
+
+const changeImportNotLocalInput = {
+	source: normalizeLineEndings(`
+import { tsx, w } from '@dojo/framework/core/vdom';
+import { Outlet as MyOutletName } from '@dojo/framework/routing/Outlet';
+function foo() {
+    return <MyOutletName/>;
+}
+function bar() {
+    return w(MyOutletName);
+}
+`)
+};
+
+const doNotChangeDefaultImportInput = {
+	source: normalizeLineEndings(`
+import { tsx, w } from '@dojo/framework/core/vdom';
+import MyOutletName  from '@dojo/framework/routing/Outlet';
+function foo() {
+    return <MyOutletName/>;
+}
+function bar() {
+    return w(MyOutletName);
+}
+`)
+};
+
+describe('outlet-to-route', () => {
+	it('transforms default import', () => {
+		const output = moduleTransform(changeDefaultImportInput, { jscodeshift, stats: () => {} });
+		assert.equal(
+			output,
+			normalizeLineEndings(`
+import { tsx, w } from '@dojo/framework/core/vdom';
+import Route from '@dojo/framework/routing/Route';
+const Foo: any = {};
+function foo() {
+    return <Route/>;
+}
+function bar() {
+    return w(Route);
+}
+function baz() {
+    return w(Foo);
+}
+`)
+		);
+	});
+
+	it('transforms named import, failing to detect block scope', () => {
+		const output = moduleTransform(changeImportInput, { jscodeshift, stats: () => {} });
+		assert.equal(
+			output,
+			normalizeLineEndings(`
+import { tsx, w } from '@dojo/framework/core/vdom';
+import { Route } from '@dojo/framework/routing/Route';
+function foo() {
+    return <Route/>;
+}
+function bar() {
+    return w(Route);
+}
+if (true) {
+    const Route = 'A Bad Idea';
+    console.log(Route);
+}
+`)
+		);
+	});
+
+	it('transforms named import, successfully  detecting function scope', () => {
+		const output = moduleTransform(changeImportInputNewScope, { jscodeshift, stats: () => {} });
+		assert.equal(
+			output,
+			normalizeLineEndings(`
+import { tsx, w } from '@dojo/framework/core/vdom';
+import { Route } from '@dojo/framework/routing/Route';
+function foo() {
+    return <Route/>;
+}
+function bar() {
+    return w(Route);
+}
+(() => {
+    const Outlet = 'A Bad Idea';
+    console.log(Outlet);
+})();
+`)
+		);
+	});
+
+	it('transforms named import source but not local name if aliased', () => {
+		const output = moduleTransform(changeImportNotLocalInput, { jscodeshift, stats: () => {} });
+		assert.equal(
+			output,
+			normalizeLineEndings(`
+import { tsx, w } from '@dojo/framework/core/vdom';
+import { Route as MyOutletName } from '@dojo/framework/routing/Route';
+function foo() {
+    return <MyOutletName/>;
+}
+function bar() {
+    return w(MyOutletName);
+}
+`)
+		);
+	});
+
+	it('Does not change default import name if it is not `Outlet`', () => {
+		const output = moduleTransform(doNotChangeDefaultImportInput, { jscodeshift, stats: () => {} });
+		assert.equal(
+			output,
+			normalizeLineEndings(`
+import { tsx, w } from '@dojo/framework/core/vdom';
+import MyOutletName  from '@dojo/framework/routing/Route';
+function foo() {
+    return <MyOutletName/>;
+}
+function bar() {
+    return w(MyOutletName);
+}
+`)
+		);
+	});
+});


### PR DESCRIPTION
Transforms `Outlet` references to instead reference `Route`.

jscodeshift is unable to detect block scopes so I don't see anyway we can guarantee we won't alter a shadowed variable when refactoring.

Builds on #54 

Resolves #52 