### PR TITLE
Fix migrations

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,7 @@ export class UpgradeCommand implements Command {
 		const { pattern, dry } = args;
 		const paths = glob.sync(pattern);
 		const hasJSX = paths.some((p: string) => p.match(/\.tsx$/g));
-		const parser = hasJSX ? 'ts-jsx' : 'ts';
+		const parser = hasJSX ? 'tsx' : 'ts';
 		const fromVersion = this.depManager.getDojoVersion();
 		const toVersion = LATEST_VERSION;
 

--- a/src/v7/transforms/route-ids.ts
+++ b/src/v7/transforms/route-ids.ts
@@ -17,25 +17,37 @@ export default function(file: any, api: any) {
 			.replaceWith((p: any) => {
 				if (p.node && p.node.properties) {
 					const outlet = p.node.properties.reduce(
-						(outlet: string | boolean, property: any) =>
-							outlet ? outlet : property.key.name === 'outlet' && property.value.value,
+						(outlet: string | boolean | any, property: any) =>
+							outlet
+								? outlet
+								: property.key.name === 'outlet' &&
+								  (property.value.type === 'StringLiteral' ? property.value.value : property.value),
 						false
 					);
 					if (outlet) {
+						debugger;
 						if (!quote) {
 							quote = p.node.properties[0].value.extra.raw[0] === '"' ? 'double' : 'single';
 						}
+						let value: any;
+						if (typeof outlet === 'string') {
+							value = j.stringLiteral(outlet);
+						} else if (outlet.type === 'MemberExpression') {
+							value = j.memberExpression(outlet.object, outlet.property);
+						} else if (outlet.type === 'Identifier') {
+							value = j.identifier(outlet.name);
+						}
+
 						return {
 							...p.node,
-							properties: [
-								...p.node.properties,
-								j.objectProperty(j.identifier('id'), j.stringLiteral(outlet))
-							]
+							properties: value
+								? [...p.node.properties, j.objectProperty(j.identifier('id'), value)]
+								: [...p.node.properties]
 						};
 					}
 				}
 
-				return p;
+				return { ...p.node };
 			})
 			.toSource({ quote: quote || 'single', lineTerminator });
 	} else {

--- a/src/v7/transforms/route-ids.ts
+++ b/src/v7/transforms/route-ids.ts
@@ -25,7 +25,6 @@ export default function(file: any, api: any) {
 						false
 					);
 					if (outlet) {
-						debugger;
 						if (!quote) {
 							quote = p.node.properties[0].value.extra.raw[0] === '"' ? 'double' : 'single';
 						}

--- a/tests/unit/v7/transforms/route-ids.ts
+++ b/tests/unit/v7/transforms/route-ids.ts
@@ -16,12 +16,31 @@ const input = {
 export default [
     {
         path: 'home',
-        outlet: 'home',
+        outlet: a.nested.identifier,
         defaultRoute: true
     },
     {
         path: 'about',
-        outlet: 'about'
+        outlet: anIdentifier,
+        children: [
+            {
+                path: 'child',
+                outlet: 'child',
+                children: [
+                    {
+                        path: 'child-child',
+                        outlet: 'child-child'
+                    }
+                ],
+				defaultParams: {
+					hideMenu: 'true'
+				}
+            },
+            {
+                path: 'child2',
+                outlet: 'child2'
+            }
+        ]
     },
     {
         path: 'profile',
@@ -40,14 +59,41 @@ describe('route-ids', () => {
 export default [
     {
         path: 'home',
-        outlet: 'home',
+        outlet: a.nested.identifier,
         defaultRoute: true,
-        id: 'home'
+        id: a.nested.identifier
     },
     {
         path: 'about',
-        outlet: 'about',
-        id: 'about'
+        outlet: anIdentifier,
+
+        children: [
+            {
+                path: 'child',
+                outlet: 'child',
+
+                children: [
+                    {
+                        path: 'child-child',
+                        outlet: 'child-child',
+                        id: 'child-child'
+                    }
+                ],
+
+                defaultParams: {
+					hideMenu: 'true'
+				},
+
+                id: 'child'
+            },
+            {
+                path: 'child2',
+                outlet: 'child2',
+                id: 'child2'
+            }
+        ],
+
+        id: anIdentifier
     },
     {
         path: 'profile',
@@ -67,14 +113,41 @@ export default [
 export default [
     {
         path: 'home',
-        outlet: 'home',
+        outlet: a.nested.identifier,
         defaultRoute: true,
-        id: 'home'
+        id: a.nested.identifier
     },
     {
         path: 'about',
-        outlet: 'about',
-        id: 'about'
+        outlet: anIdentifier,
+
+        children: [
+            {
+                path: 'child',
+                outlet: 'child',
+
+                children: [
+                    {
+                        path: 'child-child',
+                        outlet: 'child-child',
+                        id: 'child-child'
+                    }
+                ],
+
+                defaultParams: {
+					hideMenu: 'true'
+				},
+
+                id: 'child'
+            },
+            {
+                path: 'child2',
+                outlet: 'child2',
+                id: 'child2'
+            }
+        ],
+
+        id: anIdentifier
     },
     {
         path: 'profile',


### PR DESCRIPTION
The parser type "ts-jsx" does not appear to work correctly. I've updated it to `tsx' as indicated [in the docs](https://github.com/facebook/jscodeshift#parser) for jscodeshift. Running these against a larger project also revealed some issues with the routeId migration which I've addressed. 