### PR TITLE
Convert middleware result to Default MiddlewareResult

### DIFF
--- a/src/v7/main.ts
+++ b/src/v7/main.ts
@@ -15,6 +15,10 @@ export const config: VersionConfig = {
 		{
 			name: 'Update Outlet dependencies to Route',
 			path: resolve(__dirname, 'transforms', 'outlet-to-route.js')
+		},
+		{
+			name: 'Convert MiddlewareResult type to DefaultMiddlewareResult',
+			path: resolve(__dirname, 'transforms', 'middleware-result.js')
 		}
 	],
 	dependencies: {

--- a/src/v7/transforms/middleware-result.ts
+++ b/src/v7/transforms/middleware-result.ts
@@ -5,7 +5,7 @@ export default function(file: any, api: any) {
 	const j = api.jscodeshift;
 	const lineTerminator = getLineEndings(file.source);
 	let jFile = j(file.source);
-	let importName: string = '';
+	let importName = '';
 
 	jFile.find(j.ImportDeclaration).forEach((path: any) => {
 		const { source, specifiers } = path.node;
@@ -50,7 +50,6 @@ export default function(file: any, api: any) {
 				node.typeAnnotation &&
 				(node.typeAnnotation.type === 'TSUnionType' || node.typeAnnotation.type === 'TSIntersectionType')
 			) {
-				debugger;
 				return {
 					...node,
 					typeAnnotation: {

--- a/src/v7/transforms/middleware-result.ts
+++ b/src/v7/transforms/middleware-result.ts
@@ -1,0 +1,57 @@
+import { getLineEndings } from '../../util';
+
+export default function(file: any, api: any) {
+	let quote: string | undefined;
+	const j = api.jscodeshift;
+	const lineTerminator = getLineEndings(file.source);
+	let jFile = j(file.source);
+	let importName: string = '';
+
+	jFile.find(j.ImportDeclaration).forEach((path: any) => {
+		const { source, specifiers } = path.node;
+		if (source.value && source.value === '@dojo/framework/core/interfaces') {
+			if (specifiers) {
+				specifiers.forEach((specifier: any) => {
+					if (specifier.type === 'ImportSpecifier') {
+						if (specifier.imported.name === 'MiddlewareResult') {
+							importName = specifier.local.name;
+							specifier.imported.name = 'DefaultMiddlewareResult';
+							specifier.local.name = 'DefaultMiddlewareResult';
+						}
+					}
+				});
+			}
+		}
+
+		if (!quote) {
+			quote = source.extra.raw.substr(0, 1) === '"' ? 'double' : 'single';
+		}
+
+		return { ...path.node, source: { ...source }, specifiers: [...specifiers] };
+	});
+
+	debugger;
+	if (importName) {
+		jFile.find(j.TSTypeAnnotation).replaceWith(function(path: any) {
+			const node = path.value;
+			if (
+				node.typeAnnotation &&
+				node.typeAnnotation.typeName &&
+				node.typeAnnotation.typeName.name === importName
+			) {
+				return {
+					...node,
+					typeAnnotation: {
+						...node.typeAnnotation,
+						typeName: j.identifier('DefaultMiddlewareResult'),
+						typeParameters: undefined
+					}
+				};
+			}
+
+			return node;
+		});
+	}
+
+	return jFile.toSource({ quote: quote || 'single', lineTerminator });
+}

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -10,3 +10,4 @@ import './v6/transforms/core-refactor';
 import './v7/transforms/new-test-harness';
 import './v7/transforms/route-ids';
 import './v7/transforms/outlet-to-route';
+import './v7/transforms/middleware-result';

--- a/tests/unit/v7/transforms/middleware-result.ts
+++ b/tests/unit/v7/transforms/middleware-result.ts
@@ -1,0 +1,52 @@
+const { describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import { EOL } from 'os';
+
+const normalizeLineEndings = (str: string) => str.replace(/\r?\n/g, EOL);
+
+let jscodeshift = require('jscodeshift');
+import moduleTransform from '../../../../src/v7/transforms/middleware-result';
+
+jscodeshift = jscodeshift.withParser('tsx');
+
+const changeImport = {
+	source: normalizeLineEndings(`
+import { tsx, w } from '@dojo/framework/core/vdom';
+import { MiddlewareResult } from '@dojo/framework/core/interfaces';
+const Foo: MiddlewareResult<any, any, any> = {};
+`)
+};
+
+const changeNamedImport = {
+	source: normalizeLineEndings(`
+import { tsx, w } from '@dojo/framework/core/vdom';
+import { MiddlewareResult as Alias } from '@dojo/framework/core/interfaces';
+const Foo: Alias<any, any, any> = {};
+`)
+};
+
+describe('middleware-result', () => {
+	it('transforms import', () => {
+		const output = moduleTransform(changeImport, { jscodeshift, stats: () => {} });
+		assert.equal(
+			output,
+			normalizeLineEndings(`
+import { tsx, w } from '@dojo/framework/core/vdom';
+import { DefaultMiddlewareResult } from '@dojo/framework/core/interfaces';
+const Foo: DefaultMiddlewareResult = {};
+`)
+		);
+	});
+
+	it('transforms named import', () => {
+		const output = moduleTransform(changeNamedImport, { jscodeshift, stats: () => {} });
+		assert.equal(
+			output,
+			normalizeLineEndings(`
+import { tsx, w } from '@dojo/framework/core/vdom';
+import { DefaultMiddlewareResult as DefaultMiddlewareResult } from '@dojo/framework/core/interfaces';
+const Foo: DefaultMiddlewareResult = {};
+`)
+		);
+	});
+});

--- a/tests/unit/v7/transforms/middleware-result.ts
+++ b/tests/unit/v7/transforms/middleware-result.ts
@@ -14,6 +14,8 @@ const changeImport = {
 import { tsx, w } from '@dojo/framework/core/vdom';
 import { MiddlewareResult } from '@dojo/framework/core/interfaces';
 const Foo: MiddlewareResult<any, any, any> = {};
+const bar: void | MiddlewareResult<any, any, any> = {};
+const baz: { foo: string } & MiddlewareResult<any, any, any> = {};
 `)
 };
 
@@ -34,6 +36,8 @@ describe('middleware-result', () => {
 import { tsx, w } from '@dojo/framework/core/vdom';
 import { DefaultMiddlewareResult } from '@dojo/framework/core/interfaces';
 const Foo: DefaultMiddlewareResult = {};
+const bar: void | DefaultMiddlewareResult = {};
+const baz: { foo: string } & DefaultMiddlewareResult = {};
 `)
 		);
 	});


### PR DESCRIPTION
Converts `MiddlewareResult` as a type annotation, or in union or intersection type annotations, with `DefaultMiddlewareResult` and replaces it in the import.

Resolve #59 